### PR TITLE
fix(CircularPercentIndicator): Fix Android color fill is incomplete.

### DIFF
--- a/lib/circular_percent_indicator.dart
+++ b/lib/circular_percent_indicator.dart
@@ -139,8 +139,8 @@ class _CircularPercentIndicatorState extends State<CircularPercentIndicator>
     }
 
     return Material(
+      color: widget.fillColor,
       child: Container(
-          color: widget.fillColor,
           child: Column(
             mainAxisAlignment: MainAxisAlignment.center,
             mainAxisSize: MainAxisSize.min,


### PR DESCRIPTION
In Android, when using fillColor, there will be problems with incomplete filling, like adding a border.