### PR TITLE
Correcting animation update bug

### DIFF
--- a/lib/linear_percent_indicator.dart
+++ b/lib/linear_percent_indicator.dart
@@ -29,7 +29,7 @@ class LinearPercentIndicator extends StatefulWidget {
   ///widget at the right of the Line
   final Widget trailing;
 
-  ///widget inside the circle
+  ///widget inside the Line
   final Widget center;
 
   ///The kind of finish to place on the end of lines drawn, values supported: butt, round, roundAll

--- a/lib/linear_percent_indicator.dart
+++ b/lib/linear_percent_indicator.dart
@@ -29,8 +29,8 @@ class LinearPercentIndicator extends StatefulWidget {
   ///widget at the right of the Line
   final Widget trailing;
 
-  ///widget inside the Line, an option to show a widget instead of numeric value
-  final Widget textValue;
+  ///widget inside the circle
+  final Widget center;
 
   ///The kind of finish to place on the end of lines drawn, values supported: butt, round, roundAll
   final LinearStrokeCap linearStrokeCap;
@@ -53,7 +53,7 @@ class LinearPercentIndicator extends StatefulWidget {
         this.animationDuration = 500,
         this.leading,
         this.trailing,
-        this.textValue,
+        this.center,
         this.linearStrokeCap,
         this.padding = const EdgeInsets.symmetric(horizontal: 10.0),
         this.alignment = MainAxisAlignment.start})
@@ -133,13 +133,13 @@ class _LinearPercentIndicatorState extends State<LinearPercentIndicator>
         child: CustomPaint(
           painter: LinearPainter(
               progress: _percent,
-              center: widget.textValue,
+              center: widget.center,
               progressColor: widget.progressColor,
               backgroundColor: widget.backgroundColor,
               linearStrokeCap: widget.linearStrokeCap,
               lineWidth: widget.lineHeight),
-          child: (widget.textValue != null)
-              ? Center(child: widget.textValue)
+          child: (widget.center != null)
+              ? Center(child: widget.center)
               : Container(),
         )));
 


### PR DESCRIPTION
1 -Changing the widget name.
Changing the name of the widget that is in the center of the component to be more intuitive and standardize with the LinearPercentIndicator component.

2 - When the LinearPercentIndicator is first created, it was defined in 

```
initState () {
.
.
.
_animation = new Tween (begin: 0.0, end: widget.percent)
}
```

this forced the value of the end to never be updated without recreating everything again.

I modified it so that the final value was the maximum acceptable "1.0", so when the component receives new data it behaves correctly.

To test this, just have a list of LinearPercentIndicator and pass a value of 0.0 to it and then update the values of the list, you will see that the value drawn in the progressColor will always be the same.

3 - When the value is 0 it still paints a starting point, I modified it to be transparent when the value is equal to 0.0 para ficar igual ao CircularPercentIndicator