### PR TITLE
Animate decrease in progress

### DIFF
--- a/lib/linear_percent_indicator.dart
+++ b/lib/linear_percent_indicator.dart
@@ -113,8 +113,7 @@ class _LinearPercentIndicatorState extends State<LinearPercentIndicator>
         _animationController.duration =
             Duration(milliseconds: widget.animationDuration);
         _animation = Tween(
-                begin: widget.animateFromLastPercent &&
-                        oldWidget.percent < widget.percent
+                begin: widget.animateFromLastPercent
                     ? oldWidget.percent
                     : 0.0,
                 end: widget.percent)


### PR DESCRIPTION
Fixed an error causing regression (declining progression) to
animate from 0 instead of the last value.
This happened regardless if the `animateFromLastPercent` was set
too true or not.

The error was an unnecessary logical operation checking if the new value
was larger than the old.
Removing this statement fixed the bug and does not effect any other code.