### PR TITLE
Fix test by adding MaterialApp

### DIFF
--- a/test/percent_indicator_test.dart
+++ b/test/percent_indicator_test.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/material.dart';
 import 'package:percent_indicator/percent_indicator.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -10,7 +11,7 @@ void main() {
 
    testWidgets('testing linear percent indicator widget', (WidgetTester tester) async {
     LinearPercentIndicator localWidget = new LinearPercentIndicator(width: 100.0,);
-    await tester.pumpWidget(localWidget);
+    await tester.pumpWidget(MaterialApp(home: localWidget));
     expect(localWidget.percent, 0.0);
   });
 


### PR DESCRIPTION
Without this fix, the test crashes with `textDirection != null` failed assert. There’s probably Flex used in the percent indicator, and Flex needs a text direction.