### PR TITLE
Added import code to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,12 @@ There is a example project in the `example` folder. Check it out. Otherwise, kee
 
 **Circular percent indicator**
 
+Need to include the import the package to the dart file where it will be used, use the below command,
+
+```dart
+import 'package:percent_indicator/percent_indicator.dart';
+```
+
 Basic Widget
 ```dart
 new CircularPercentIndicator(

--- a/README.md
+++ b/README.md
@@ -37,13 +37,12 @@ There is a example project in the `example` folder. Check it out. Otherwise, kee
 
 ## Usage
 
-**Circular percent indicator**
-
 Need to include the import the package to the dart file where it will be used, use the below command,
 
 ```dart
 import 'package:percent_indicator/percent_indicator.dart';
 ```
+**Circular percent indicator**
 
 Basic Widget
 ```dart


### PR DESCRIPTION
Hi @diegoveloper ,
Thank you for the awesome plugin, it seems to be the import code which is used to import the flutter_percent_indicator is not added to the README.md. It takes sometime to search in the codebase to find that. This PR  updates the REAME.md . 