### PR TITLE
Added optional backgroundWidth

### DIFF
--- a/example/lib/sample_circular_page.dart
+++ b/example/lib/sample_circular_page.dart
@@ -139,6 +139,18 @@ class _SampleCircularPageState extends State<SampleCircularPage> {
                 CircularPercentIndicator(
                   radius: 45.0,
                   lineWidth: 4.0,
+                  backgroundWidth: 1.0,
+                  percent: 0.2,
+                  animation: true,
+                  center: Text("20%"),
+                  progressColor: Colors.orangeAccent,
+                ),
+                Padding(
+                  padding: EdgeInsets.symmetric(horizontal: 10.0),
+                ),
+                CircularPercentIndicator(
+                  radius: 45.0,
+                  lineWidth: 4.0,
                   percent: 0.30,
                   center: Text("30%"),
                   progressColor: Colors.orange,
@@ -149,9 +161,10 @@ class _SampleCircularPageState extends State<SampleCircularPage> {
                 CircularPercentIndicator(
                   radius: 45.0,
                   lineWidth: 4.0,
+                  backgroundWidth: 8,
                   animation: true,
                   animationDuration: 200,
-                  percent: 0.30,
+                  percent: 0.60,
                   center: Text("60%"),
                   progressColor: Colors.yellow,
                 ),
@@ -178,7 +191,7 @@ class _SampleCircularPageState extends State<SampleCircularPage> {
                     child: Icon(Icons.person),
                   ),
                   progressColor: Colors.redAccent,
-                )
+                ),
               ],
             ),
           )

--- a/lib/circular_percent_indicator.dart
+++ b/lib/circular_percent_indicator.dart
@@ -15,8 +15,11 @@ class CircularPercentIndicator extends StatefulWidget {
   final double percent;
   final double radius;
 
-  ///Width of the line of the Circle
+  ///Width of the progress bar of the circle
   final double lineWidth;
+  
+  ///Width of the unfilled background of the progress bar
+  final double backgroundWidth;
 
   ///Color of the background of the circle , default = transparent
   final Color fillColor;
@@ -80,7 +83,8 @@ class CircularPercentIndicator extends StatefulWidget {
       @required this.radius,
       this.fillColor = Colors.transparent,
       this.backgroundColor = const Color(0xFFB8C7CB),
-      Color progressColor,
+      Color progressColor, 
+      this.backgroundWidth = -1, //negative values ignored, replaced with lineWidth
       this.linearGradient,
       this.animation = false,
       this.animationDuration = 500,
@@ -198,6 +202,9 @@ class _CircularPercentIndicatorState extends State<CircularPercentIndicator>
               circularStrokeCap: widget.circularStrokeCap,
               radius: (widget.radius / 2) - widget.lineWidth / 2,
               lineWidth: widget.lineWidth,
+              backgroundWidth: //negative values ignored, replaced with lineWidth
+                widget.backgroundWidth >= 0.0?
+                  (widget.backgroundWidth): widget.lineWidth,
               arcBackgroundColor: widget.arcBackgroundColor,
               arcType: widget.arcType,
               reverse: widget.reverse,
@@ -232,6 +239,7 @@ class CirclePainter extends CustomPainter {
   final Paint _paintLine = Paint();
   final Paint _paintBackgroundStartAngle = Paint();
   final double lineWidth;
+  final double backgroundWidth;
   final double progress;
   final double radius;
   final Color progressColor;
@@ -246,6 +254,7 @@ class CirclePainter extends CustomPainter {
 
   CirclePainter(
       {this.lineWidth,
+      this.backgroundWidth,
       this.progress,
       @required this.radius,
       this.progressColor,
@@ -259,7 +268,7 @@ class CirclePainter extends CustomPainter {
       this.maskFilter}) {
     _paintBackground.color = backgroundColor;
     _paintBackground.style = PaintingStyle.stroke;
-    _paintBackground.strokeWidth = lineWidth;
+    _paintBackground.strokeWidth = backgroundWidth;
 
     if (arcBackgroundColor != null) {
       _paintBackgroundStartAngle.color = arcBackgroundColor;


### PR DESCRIPTION
Implements feature request #62 
The backgroundWidth property can be used to make a thinner 'remaining'
bar or a thicker border

Example with thicker background:
![20200604_000704](https://user-images.githubusercontent.com/1209150/83717514-86303480-a5f8-11ea-81d8-395b3140ae67.jpg)

Example with thinner background:
![20200604_000634](https://user-images.githubusercontent.com/1209150/83717521-89c3bb80-a5f8-11ea-8a8e-31b15cde31eb.jpg)
