### PR TITLE
Added a flag called animateForwardAlways to make sure if animateFromLastPercent is set, the progress bar doesn't animate backwards

### DIFF
--- a/lib/linear_percent_indicator.dart
+++ b/lib/linear_percent_indicator.dart
@@ -47,6 +47,9 @@ class LinearPercentIndicator extends StatefulWidget {
 
   /// set true if you want to animate the linear from the last percent value you set
   final bool animateFromLastPercent;
+  
+  /// set true if you want to always animate the linear forward
+  final bool animateForwardAlways;
 
   /// If present, this will make the progress bar colored by this gradient.
   ///
@@ -91,6 +94,7 @@ class LinearPercentIndicator extends StatefulWidget {
     this.animation = false,
     this.animationDuration = 500,
     this.animateFromLastPercent = false,
+    this.animateForwardAlways = false,
     this.isRTL = false,
     this.leading,
     this.trailing,
@@ -197,7 +201,7 @@ class _LinearPercentIndicatorState extends State<LinearPercentIndicator>
         _animationController!.duration =
             Duration(milliseconds: widget.animationDuration);
         _animation = Tween(
-                begin: widget.animateFromLastPercent ? oldWidget.percent : 0.0,
+                begin: (widget.animateFromLastPercent && (!widget.animateForwardAlways ||  widget.percent > oldWidget.percent) ? oldWidget.percent : 0.0,
                 end: widget.percent)
             .animate(
           CurvedAnimation(parent: _animationController!, curve: widget.curve),

--- a/lib/linear_percent_indicator.dart
+++ b/lib/linear_percent_indicator.dart
@@ -201,7 +201,7 @@ class _LinearPercentIndicatorState extends State<LinearPercentIndicator>
         _animationController!.duration =
             Duration(milliseconds: widget.animationDuration);
         _animation = Tween(
-                begin: (widget.animateFromLastPercent && (!widget.animateForwardAlways ||  widget.percent > oldWidget.percent) ? oldWidget.percent : 0.0,
+                begin: (widget.animateFromLastPercent && (!widget.animateForwardAlways ||  widget.percent > oldWidget.percent)) ? oldWidget.percent : 0.0,
                 end: widget.percent)
             .animate(
           CurvedAnimation(parent: _animationController!, curve: widget.curve),


### PR DESCRIPTION
Adding the `animateForwardAlways` flag will enable a user to set `animateFromLastPercent` but limit the behavior to only happen if the progress bar is moving forward (newPercentage > oldPercentage). 

This behavior is needed for cases when the progress bar received percentage updates but sometimes needs to reset from zero (a browser loading bar, for example).