### PR TITLE
Add more info to the incorrect progress value Exception

### DIFF
--- a/lib/circular_percent_indicator.dart
+++ b/lib/circular_percent_indicator.dart
@@ -139,7 +139,7 @@ class CircularPercentIndicator extends StatefulWidget {
 
     assert(startAngle >= 0.0);
     if (percent < 0.0 || percent > 1.0) {
-      throw Exception("Percent value must be a double between 0.0 and 1.0");
+      throw Exception("Percent value must be a double between 0.0 and 1.0, but it's $percent");
     }
 
     if (arcType == null && arcBackgroundColor != null) {

--- a/lib/linear_percent_indicator.dart
+++ b/lib/linear_percent_indicator.dart
@@ -124,7 +124,7 @@ class LinearPercentIndicator extends StatefulWidget {
     _backgroundColor = backgroundColor ?? Color(0xFFB8C7CB);
 
     if (percent < 0.0 || percent > 1.0) {
-      throw new Exception("Percent value must be a double between 0.0 and 1.0");
+      throw new Exception("Percent value must be a double between 0.0 and 1.0, but it's $percent");
     }
   }
 


### PR DESCRIPTION
Hello! 👋 

We're using this project on production, and we found this message on Crashlytics:

![image](https://user-images.githubusercontent.com/456499/135834125-265e1170-79bc-42dc-a201-3f45863b9c52.png)

It's a good message, but it would be better if we knew the value we are passing. So this PR adds the actual value to the Exception.