### PR TITLE
Rollback WidgetsBinding.instance null-aware operator for Flutter 2.10 or earlier.

### DIFF
--- a/lib/linear_percent_indicator.dart
+++ b/lib/linear_percent_indicator.dart
@@ -159,7 +159,7 @@ class _LinearPercentIndicatorState extends State<LinearPercentIndicator>
 
   @override
   void initState() {
-    WidgetsBinding.instance.addPostFrameCallback((_) {
+    WidgetsBinding?.instance.addPostFrameCallback((_) {
       if (mounted) {
         setState(() {
           _containerWidth = _containerKey.currentContext?.size?.width ?? 0.0;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: percent_indicator
 description: Library that allows you to display progress widgets based on percentage, can be Circular or Linear, you can also customize it to your needs.
-version: 4.2.0
+version: 4.2.1
 homepage: https://www.diegoveloper.com
 repository: https://github.com/diegoveloper/flutter_percent_indicator/
 


### PR DESCRIPTION
Rollback WidgetsBinding.instance null-aware operator and bump the version to lock by Flutter 2.10.