### PR TITLE
Issue fixed in linear percentage indicator

### DIFF
--- a/lib/linear_percent_indicator.dart
+++ b/lib/linear_percent_indicator.dart
@@ -159,7 +159,7 @@ class _LinearPercentIndicatorState extends State<LinearPercentIndicator>
 
   @override
   void initState() {
-    WidgetsBinding.instance.addPostFrameCallback((_) {
+    WidgetsBinding.instance?.addPostFrameCallback((_) {
       if (mounted) {
         setState(() {
           _containerWidth = _containerKey.currentContext?.size?.width ?? 0.0;


### PR DESCRIPTION
the package put the null aware operator on the WidgetsBinding instead of the instance.
changed from WidgetsBinding.instance.addPostFrameCallback((_) { to WidgetsBinding.instance?.addPostFrameCallback((_) {