### PR TITLE
fix: check for hasSize for linearPercentIndicator - fix #175

### DIFF
--- a/lib/linear_percent_indicator.dart
+++ b/lib/linear_percent_indicator.dart
@@ -161,15 +161,22 @@ class _LinearPercentIndicatorState extends State<LinearPercentIndicator>
   void initState() {
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (mounted) {
-        setState(() {
-          _containerWidth = _containerKey.currentContext?.size?.width ?? 0.0;
-          _containerHeight = _containerKey.currentContext?.size?.height ?? 0.0;
-          if (_keyIndicator.currentContext != null) {
-            _indicatorWidth = _keyIndicator.currentContext?.size?.width ?? 0.0;
-            _indicatorHeight =
-                _keyIndicator.currentContext?.size?.height ?? 0.0;
-          }
-        });
+        final RenderBox box =
+            _containerKey.currentContext?.findRenderObject() as RenderBox;
+
+        if (box.hasSize) {
+          setState(() {
+            _containerWidth = _containerKey.currentContext?.size?.width ?? 0.0;
+            _containerHeight =
+                _containerKey.currentContext?.size?.height ?? 0.0;
+            if (_keyIndicator.currentContext != null) {
+              _indicatorWidth =
+                  _keyIndicator.currentContext?.size?.width ?? 0.0;
+              _indicatorHeight =
+                  _keyIndicator.currentContext?.size?.height ?? 0.0;
+            }
+          });
+        }
       }
     });
     if (widget.animation) {


### PR DESCRIPTION
This PR will check for `renderbox.haSize` in linearPercentIndicator to fix this issue https://github.com/diegoveloper/flutter_percent_indicator/issues/175

```dart
final RenderBox box =
            _containerKey.currentContext?.findRenderObject() as RenderBox;

        if (box.hasSize) {
          setState(() {
            _containerWidth = _containerKey.currentContext?.size?.width ?? 0.0;
            _containerHeight =
                _containerKey.currentContext?.size?.height ?? 0.0;
            if (_keyIndicator.currentContext != null) {
              _indicatorWidth =
                  _keyIndicator.currentContext?.size?.width ?? 0.0;
              _indicatorHeight =
                  _keyIndicator.currentContext?.size?.height ?? 0.0;
            }
          });
        }
```

Not sure how to properly create a test case for this as it require nested routes to reproduce the flutter bug. But it shouldn't break any existing test.