### PR TITLE
docs: Update readme by Changing deprecated linearStrokeCap to barRadius

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Circular and Linear percent indicators
 
 - Circle percent indicator
 - Linear percent indicator
-- Toggle animation 
+- Toggle animation
 - Custom duration of the animation
 - Progress based on a percentage value
 - Progress and background color
@@ -24,9 +24,10 @@ Circular and Linear percent indicators
 ## Getting started
 
 You should ensure that you add the router as a dependency in your flutter project.
+
 ```yaml
 dependencies:
- percent_indicator: ^4.0.1
+  percent_indicator: ^4.0.1
 ```
 
 You should then run `flutter packages upgrade` or update your packages in IntelliJ.
@@ -42,9 +43,11 @@ Need to include the import the package to the dart file where it will be used, u
 ```dart
 import 'package:percent_indicator/percent_indicator.dart';
 ```
+
 **Circular percent indicator**
 
 Basic Widget
+
 ```dart
 new CircularPercentIndicator(
                   radius: 60.0,
@@ -56,6 +59,7 @@ new CircularPercentIndicator(
 ```
 
 Complete example
+
 ```dart
   @override
   Widget build(BuildContext context) {
@@ -172,14 +176,15 @@ Complete example
     );
   }
 ```
+
 <p align="center">
   <img src="https://media.giphy.com/media/35LCxze8UGUXcZ9TIu/giphy.gif">
 </p>
 
-
 **Linear percent indicator**
 
 Basic Widget
+
 ```dart
 new LinearPercentIndicator(
                 width: 140.0,
@@ -192,6 +197,7 @@ new LinearPercentIndicator(
 ```
 
 Complete example
+
 ```dart
 @override
   Widget build(BuildContext context) {
@@ -214,7 +220,7 @@ Complete example
                   style: new TextStyle(fontSize: 12.0),
                 ),
                 trailing: Icon(Icons.mood),
-                linearStrokeCap: LinearStrokeCap.roundAll,
+                barRadius: const Radius.circular(20),
                 backgroundColor: Colors.grey,
                 progressColor: Colors.blue,
               ),
@@ -230,7 +236,6 @@ Complete example
                 trailing: new Text("right content"),
                 percent: 0.2,
                 center: Text("20.0%"),
-                linearStrokeCap: LinearStrokeCap.butt,
                 progressColor: Colors.red,
               ),
             ),
@@ -243,7 +248,7 @@ Complete example
                 animationDuration: 2000,
                 percent: 0.9,
                 center: Text("90.0%"),
-                linearStrokeCap: LinearStrokeCap.roundAll,
+                barRadius: const Radius.circular(20),
                 progressColor: Colors.greenAccent,
               ),
             ),
@@ -256,7 +261,7 @@ Complete example
                 animationDuration: 2500,
                 percent: 0.8,
                 center: Text("80.0%"),
-                linearStrokeCap: LinearStrokeCap.roundAll,
+                barRadius: const Radius.circular(20),
                 progressColor: Colors.green,
               ),
             ),
@@ -291,9 +296,9 @@ Complete example
     );
   }
 ```
+
 <p align="center">
   <img src="https://media.giphy.com/media/88j2PmdEqCrLq2pZxO/giphy.gif">
 </p>
-
 
 You can follow me on twitter [@diegoveloper](https://www.twitter.com/diegoveloper)

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.2.1"
   collection:
     dependency: transitive
     description:
@@ -26,21 +26,21 @@ packages:
       name: material_color_utilities
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.4"
+    version: "0.1.5"
   meta:
     dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.7.0"
+    version: "1.8.0"
   percent_indicator:
     dependency: "direct main"
     description:
       path: ".."
       relative: true
     source: path
-    version: "4.0.1"
+    version: "4.2.2"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -54,4 +54,5 @@ packages:
     source: hosted
     version: "2.1.2"
 sdks:
-  dart: ">=2.14.0 <3.0.0"
+  dart: ">=2.17.0-0 <3.0.0"
+  flutter: ">=2.12.0"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.8.2"
+    version: "2.9.0"
   boolean_selector:
     dependency: transitive
     description:
@@ -21,21 +21,14 @@ packages:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
-  charcode:
-    dependency: transitive
-    description:
-      name: charcode
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.3.1"
+    version: "1.2.1"
   clock:
     dependency: transitive
     description:
       name: clock
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.1"
   collection:
     dependency: transitive
     description:
@@ -49,7 +42,7 @@ packages:
       name: fake_async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0"
+    version: "1.3.1"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -66,28 +59,28 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.11"
+    version: "0.12.12"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.4"
+    version: "0.1.5"
   meta:
     dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.7.0"
+    version: "1.8.0"
   path:
     dependency: transitive
     description:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.1"
+    version: "1.8.2"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -99,7 +92,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.2"
+    version: "1.9.0"
   stack_trace:
     dependency: transitive
     description:
@@ -120,21 +113,21 @@ packages:
       name: string_scanner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.1"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.2.1"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.9"
+    version: "0.4.12"
   vector_math:
     dependency: transitive
     description:


### PR DESCRIPTION
I updated the readme to remove deprecated LinearProgressIndicator property linearStrokeCap to  barRadius.