### PR TITLE
Check in linear percent indicator state is null if the size is null

### DIFF
--- a/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/example/ios/Runner.xcodeproj/project.pbxproj
@@ -191,6 +191,7 @@
 			files = (
 			);
 			inputPaths = (
+				"${TARGET_BUILD_DIR}/${INFOPLIST_PATH}",
 			);
 			name = "Thin Binary";
 			outputPaths = (

--- a/lib/linear_percent_indicator.dart
+++ b/lib/linear_percent_indicator.dart
@@ -170,11 +170,12 @@ class _LinearPercentIndicatorState extends State<LinearPercentIndicator>
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (mounted) {
         setState(() {
-          _containerWidth = (_containerKey.currentContext?.size != null) ? _containerKey.currentContext!.size!.width : 0.0;
-          _containerHeight = (_containerKey.currentContext?.size != null) ? _containerKey.currentContext!.size!.height : 0.0;
+          _containerWidth = _containerKey.currentContext?.size?.width ?? 0.0;
+          _containerHeight = _containerKey.currentContext?.size?.height ?? 0.0;
           if (_keyIndicator.currentContext != null) {
-            _indicatorWidth = (_keyIndicator.currentContext?.size != null) ? _keyIndicator.currentContext!.size!.width : 0.0;
-            _indicatorHeight = (_keyIndicator.currentContext?.size != null) ? _keyIndicator.currentContext!.size!.height : 0.0;
+            _indicatorWidth = _keyIndicator.currentContext?.size?.width ?? 0.0;
+            _indicatorHeight =
+                _keyIndicator.currentContext?.size?.height ?? 0.0;
           }
         });
       }

--- a/lib/linear_percent_indicator.dart
+++ b/lib/linear_percent_indicator.dart
@@ -170,12 +170,11 @@ class _LinearPercentIndicatorState extends State<LinearPercentIndicator>
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (mounted) {
         setState(() {
-          _containerWidth = _containerKey.currentContext?.size?.width ?? 0.0;
-          _containerHeight = _containerKey.currentContext?.size?.height ?? 0.0;
+          _containerWidth = (_containerKey.currentContext?.size != null) ? _containerKey.currentContext!.size!.width : 0.0;
+          _containerHeight = (_containerKey.currentContext?.size != null) ? _containerKey.currentContext!.size!.height : 0.0;
           if (_keyIndicator.currentContext != null) {
-            _indicatorWidth = _keyIndicator.currentContext?.size?.width ?? 0.0;
-            _indicatorHeight =
-                _keyIndicator.currentContext?.size?.height ?? 0.0;
+            _indicatorWidth = (_keyIndicator.currentContext?.size != null) ? _keyIndicator.currentContext!.size!.width : 0.0;
+            _indicatorHeight = (_keyIndicator.currentContext?.size != null) ? _keyIndicator.currentContext!.size!.height : 0.0;
           }
         });
       }

--- a/lib/linear_percent_indicator.dart
+++ b/lib/linear_percent_indicator.dart
@@ -251,50 +251,56 @@ class _LinearPercentIndicatorState extends State<LinearPercentIndicator>
     final hasSetWidth = widget.width != null;
     final percentPositionedHorizontal =
         _containerWidth * _percent - _indicatorWidth / 3;
-    var containerWidget = Container(
-      width: hasSetWidth ? widget.width : double.infinity,
-      height: widget.lineHeight,
-      padding: widget.padding,
-      child: Stack(
-        clipBehavior: Clip.none,
-        children: [
-          CustomPaint(
-            key: _containerKey,
-            painter: _LinearPainter(
-              isRTL: widget.isRTL,
-              progress: _percent,
-              progressColor: widget.progressColor,
-              progressBorderColor: widget.progressBorderColor,
-              linearGradient: widget.linearGradient,
-              backgroundColor: widget.backgroundColor,
-              barRadius: widget.barRadius ??
-                  Radius.zero, // If radius is not defined, set it to zero
-              linearGradientBackgroundColor:
-                  widget.linearGradientBackgroundColor,
-              maskFilter: widget.maskFilter,
-              clipLinearGradient: widget.clipLinearGradient,
+    //LayoutBuilder is used to get the size of the container where the widget is rendered
+    var containerWidget = LayoutBuilder(
+        builder: (context, constraints) {
+          _containerWidth = constraints.maxWidth;
+          _containerHeight = constraints.maxHeight;
+          return Container(
+            width: hasSetWidth ? widget.width : double.infinity,
+            height: widget.lineHeight,
+            padding: widget.padding,
+            child: Stack(
+              clipBehavior: Clip.none,
+              children: [
+                CustomPaint(
+                  key: _containerKey,
+                  painter: _LinearPainter(
+                    isRTL: widget.isRTL,
+                    progress: _percent,
+                    progressColor: widget.progressColor,
+                    linearGradient: widget.linearGradient,
+                    backgroundColor: widget.backgroundColor,
+                    barRadius: widget.barRadius ??
+                        Radius.zero, // If radius is not defined, set it to zero
+                    linearGradientBackgroundColor:
+                    widget.linearGradientBackgroundColor,
+                    maskFilter: widget.maskFilter,
+                    clipLinearGradient: widget.clipLinearGradient,
+                  ),
+                  child: (widget.center != null)
+                      ? Center(child: widget.center)
+                      : Container(),
+                ),
+                if (widget.widgetIndicator != null && _indicatorWidth == 0)
+                  Opacity(
+                    opacity: 0.0,
+                    key: _keyIndicator,
+                    child: widget.widgetIndicator,
+                  ),
+                if (widget.widgetIndicator != null &&
+                    _containerWidth > 0 &&
+                    _indicatorWidth > 0)
+                  Positioned(
+                    right: widget.isRTL ? percentPositionedHorizontal : null,
+                    left: !widget.isRTL ? percentPositionedHorizontal : null,
+                    top: _containerHeight / 2 - _indicatorHeight,
+                    child: widget.widgetIndicator!,
+                  ),
+              ],
             ),
-            child: (widget.center != null)
-                ? Center(child: widget.center)
-                : Container(),
-          ),
-          if (widget.widgetIndicator != null && _indicatorWidth == 0)
-            Opacity(
-              opacity: 0.0,
-              key: _keyIndicator,
-              child: widget.widgetIndicator,
-            ),
-          if (widget.widgetIndicator != null &&
-              _containerWidth > 0 &&
-              _indicatorWidth > 0)
-            Positioned(
-              right: widget.isRTL ? percentPositionedHorizontal : null,
-              left: !widget.isRTL ? percentPositionedHorizontal : null,
-              top: _containerHeight / 2 - _indicatorHeight,
-              child: widget.widgetIndicator!,
-            ),
-        ],
-      ),
+          );
+        }
     );
 
     if (hasSetWidth) {


### PR DESCRIPTION

**Description**: 
It checks if size is null before assigning a measurement value. Sometimes it might happen that size comes as null, which is why the error occurs on certain occasions

**Error**:
```
Non-fatal Exception: io.flutter.plugins.firebase.crashlytics.FlutterError: Null check operator used on a null value. Error thrown Instance of 'ErrorDescription'.
       at RenderBox.size(box.dart:2001)
       at Element.size(framework.dart:4175)
       at _LinearPercentIndicatorState.initState.<fn>.<fn>(linear_percent_indicator.dart:165)
       at State.setState(framework.dart:1109)
       at _LinearPercentIndicatorState.initState.<fn>(linear_percent_indicator.dart:164)
       at SchedulerBinding._invokeFrameCallback(binding.dart:1146)
       at SchedulerBinding.handleDrawFrame(binding.dart:1091)
       at SchedulerBinding._handleDrawFrame(binding.dart:997)
```


**Related**: 

https://github.com/diegoveloper/flutter_percent_indicator/issues/174#issue-1341148691