### PR TITLE
check hasSize before reading size

### DIFF
--- a/lib/linear_percent_indicator.dart
+++ b/lib/linear_percent_indicator.dart
@@ -177,13 +177,14 @@ class _LinearPercentIndicatorState extends State<LinearPercentIndicator>
   void initState() {
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (mounted) {
+        final RenderObject? containerObject = _containerKey.currentContext?.findRenderObject();
+        final RenderObject? keyObject = _keyIndicator.currentContext?.findRenderObject();
         setState(() {
-          _containerWidth = _containerKey.currentContext?.size?.width ?? 0.0;
-          _containerHeight = _containerKey.currentContext?.size?.height ?? 0.0;
+          _containerWidth = (containerObject is RenderBox && containerObject.hasSize) ? containerObject.size.width : 0.0;
+          _containerHeight = (containerObject is RenderBox && containerObject.hasSize) ? containerObject.size.height : 0.0;
           if (_keyIndicator.currentContext != null) {
-            _indicatorWidth = _keyIndicator.currentContext?.size?.width ?? 0.0;
-            _indicatorHeight =
-                _keyIndicator.currentContext?.size?.height ?? 0.0;
+            _indicatorWidth = (keyObject is RenderBox && keyObject.hasSize) ? keyObject.size.width : 0.0;
+            _indicatorHeight = (keyObject is RenderBox && keyObject.hasSize) ? keyObject.size.height : 0.0;
           }
         });
       }


### PR DESCRIPTION
Fixes issue https://github.com/diegoveloper/flutter_percent_indicator/issues/175

### Description:

It seems like this can at times be called before it has been through layout (in particular when restoring state). Changed to first check `hasSize` before using `size`.

### Reproduction steps:

Using minimal sample code included below:
- In Android emulator, go to developer options and enable "Don’t keep activities"
- Run app
- Click on button to restorablePush second route
- Use device buttons to put app in background
- Use device buttons to return to the app
- It will restore and encounter this error

### Sample code:

```dart
import 'package:flutter/material.dart';
import 'package:percent_indicator/linear_percent_indicator.dart';

void main() {
  runApp(const MyApp());
}

class MyApp extends StatelessWidget {
  const MyApp({super.key});

  Widget getView(BuildContext subContext, RouteSettings routeSettings) {
    switch (routeSettings.name) {
      case WidgetB.routeName:
        return const WidgetB();
      default:
        return const WidgetA();
    }
  }

  @override
  Widget build(BuildContext context) {
    return MaterialApp(
      restorationScopeId: "test",
      onGenerateRoute: (RouteSettings routeSettings) {
        var uri = Uri.parse(routeSettings.name ?? '');
        return MaterialPageRoute<void>(
          settings: routeSettings,
          builder: (BuildContext subContext) {
            return getView(subContext, RouteSettings(
                name: uri.path,
                arguments: routeSettings.arguments ?? uri.queryParameters));
          },
        );
      },
    );
  }
}


class WidgetA extends StatefulWidget {
  static const routeName = 'widget_a';

  const WidgetA({super.key,});

  @override
  State<WidgetA> createState() => _WidgetAState();
}

class _WidgetAState extends State<WidgetA> {
  @override
  Widget build(BuildContext context) {
    return Column(children: [
      LinearPercentIndicator(),
      ElevatedButton(
        onPressed: () => Navigator.of(context).restorablePushNamed(WidgetB.routeName),
        child: const Text("Click me")
      )
    ],);
  }
}

class WidgetB extends StatefulWidget {
  static const routeName = 'widget_b';

  const WidgetB({super.key,});

  @override
  State<WidgetB> createState() => _WidgetBState();
}

class _WidgetBState extends State<WidgetB> {
  @override
  Widget build(BuildContext context) {
    return const Text("Now use device buttons to put app in background and then restore");
  }
}
```