### PR TITLE
Add possible animation loading delays

### DIFF
--- a/example/lib/sample_circular_page.dart
+++ b/example/lib/sample_circular_page.dart
@@ -26,6 +26,7 @@ class _SampleCircularPageState extends State<SampleCircularPage> {
               reverse: false,
               arcType: ArcType.FULL_REVERSED,
               startAngle: 0.0,
+              delayDuration: 300,
               animateFromLastPercent: true,
               circularStrokeCap: CircularStrokeCap.round,
               backgroundColor: Colors.green,

--- a/example/lib/sample_circular_page.dart
+++ b/example/lib/sample_circular_page.dart
@@ -8,6 +8,7 @@ class SampleCircularPage extends StatefulWidget {
 
 class _SampleCircularPageState extends State<SampleCircularPage> {
   String state = 'Animation start';
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -26,7 +27,6 @@ class _SampleCircularPageState extends State<SampleCircularPage> {
               reverse: false,
               arcType: ArcType.FULL_REVERSED,
               startAngle: 0.0,
-              delayDuration: 300,
               animateFromLastPercent: true,
               circularStrokeCap: CircularStrokeCap.round,
               backgroundColor: Colors.green,

--- a/example/lib/sample_linear_page.dart
+++ b/example/lib/sample_linear_page.dart
@@ -41,6 +41,7 @@ class _SampleLinearPageState extends State<SampleLinearPage> {
                   animateFromLastPercent: true,
                   center: Text("50.0%"),
                   progressColor: Colors.red,
+                  delayDuration: 300,
                   widgetIndicator: RotatedBox(
                       quarterTurns: 1,
                       child: Icon(Icons.airplanemode_active, size: 50)),

--- a/example/lib/sample_linear_page.dart
+++ b/example/lib/sample_linear_page.dart
@@ -41,7 +41,6 @@ class _SampleLinearPageState extends State<SampleLinearPage> {
                   animateFromLastPercent: true,
                   center: Text("50.0%"),
                   progressColor: Colors.red,
-                  delayDuration: 300,
                   widgetIndicator: RotatedBox(
                       quarterTurns: 1,
                       child: Icon(Icons.airplanemode_active, size: 50)),

--- a/lib/circular_percent_indicator.dart
+++ b/lib/circular_percent_indicator.dart
@@ -110,9 +110,6 @@ class CircularPercentIndicator extends StatefulWidget {
   /// Return current percent value if animation is true.
   final Function(double value)? onPercentValue;
 
-  /// set a delay duration in milliseconds to show the progress
-  final int delayDuration;
-
   CircularPercentIndicator({
     Key? key,
     this.percent = 0.0,
@@ -145,7 +142,6 @@ class CircularPercentIndicator extends StatefulWidget {
     this.rotateLinearGradient = false,
     this.progressBorderColor,
     this.onPercentValue,
-    this.delayDuration = 0,
   }) : super(key: key) {
     if (linearGradient != null && progressColor != null) {
       throw ArgumentError(
@@ -175,6 +171,7 @@ class _CircularPercentIndicatorState extends State<CircularPercentIndicator>
   Animation? _animation;
   double _percent = 0.0;
   double _diameter = 0.0;
+  Animation<double>? _routeAnimation;
 
   @override
   void dispose() {
@@ -210,13 +207,6 @@ class _CircularPercentIndicatorState extends State<CircularPercentIndicator>
           widget.onAnimationEnd!();
         }
       });
-      if(widget.delayDuration > 0) {
-        Future.delayed(Duration(milliseconds: widget.delayDuration), (){
-          _animationController!.forward();
-        });
-      } else {
-        _animationController!.forward();
-      }
     } else {
       _updateProgress();
     }
@@ -256,6 +246,24 @@ class _CircularPercentIndicatorState extends State<CircularPercentIndicator>
 
   _updateProgress() {
     setState(() => _percent = widget.percent);
+  }
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    if (_routeAnimation == null) {
+      _routeAnimation =
+          ModalRoute.of(context)?.animation ?? kAlwaysCompleteAnimation;
+      _routeAnimation!.addStatusListener(_handleAnimationStatusChange);
+    }
+  }
+
+  void _handleAnimationStatusChange(AnimationStatus status) {
+    if (status == AnimationStatus.completed) {
+      if(widget.animation){
+        _animationController?.forward();
+      }
+    }
   }
 
   @override

--- a/lib/circular_percent_indicator.dart
+++ b/lib/circular_percent_indicator.dart
@@ -110,6 +110,9 @@ class CircularPercentIndicator extends StatefulWidget {
   /// Return current percent value if animation is true.
   final Function(double value)? onPercentValue;
 
+  /// set a delay duration in milliseconds to show the progress
+  final int delayDuration;
+
   CircularPercentIndicator({
     Key? key,
     this.percent = 0.0,
@@ -142,6 +145,7 @@ class CircularPercentIndicator extends StatefulWidget {
     this.rotateLinearGradient = false,
     this.progressBorderColor,
     this.onPercentValue,
+    this.delayDuration = 0,
   }) : super(key: key) {
     if (linearGradient != null && progressColor != null) {
       throw ArgumentError(
@@ -182,6 +186,7 @@ class _CircularPercentIndicatorState extends State<CircularPercentIndicator>
 
   @override
   void initState() {
+
     if (widget.animation) {
       if (!widget.animateToInitialPercent) _percent = widget.percent;
       _animationController = AnimationController(
@@ -205,7 +210,13 @@ class _CircularPercentIndicatorState extends State<CircularPercentIndicator>
           widget.onAnimationEnd!();
         }
       });
-      _animationController!.forward();
+      if(widget.delayDuration > 0) {
+        Future.delayed(Duration(milliseconds: widget.delayDuration), (){
+          _animationController!.forward();
+        });
+      } else {
+        _animationController!.forward();
+      }
     } else {
       _updateProgress();
     }

--- a/lib/linear_percent_indicator.dart
+++ b/lib/linear_percent_indicator.dart
@@ -101,9 +101,6 @@ class LinearPercentIndicator extends StatefulWidget {
   /// Return current percent value if animation is true.
   final Function(double value)? onPercentValue;
 
-  /// set a delay duration in milliseconds to show the progress
-  final int delayDuration;
-
   LinearPercentIndicator({
     Key? key,
     this.fillColor = Colors.transparent,
@@ -135,7 +132,6 @@ class LinearPercentIndicator extends StatefulWidget {
     this.widgetIndicator,
     this.progressBorderColor,
     this.onPercentValue,
-    this.delayDuration = 0,
   }) : super(key: key) {
     if (linearGradient != null && progressColor != null) {
       throw ArgumentError(
@@ -170,6 +166,8 @@ class _LinearPercentIndicatorState extends State<LinearPercentIndicator>
   double _containerHeight = 0.0;
   double _indicatorWidth = 0.0;
   double _indicatorHeight = 0.0;
+  Animation<double>? _routeAnimation;
+
 
   @override
   void dispose() {
@@ -214,13 +212,6 @@ class _LinearPercentIndicatorState extends State<LinearPercentIndicator>
           widget.onAnimationEnd!();
         }
       });
-      if(widget.delayDuration > 0){
-        Future.delayed(Duration(milliseconds: widget.delayDuration), (){
-          _animationController!.forward();
-        });
-      } else {
-        _animationController!.forward();
-      }
     } else {
       _updateProgress();
     }
@@ -261,6 +252,25 @@ class _LinearPercentIndicatorState extends State<LinearPercentIndicator>
       _percent = widget.percent;
     });
   }
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    if (_routeAnimation == null) {
+      _routeAnimation =
+          ModalRoute.of(context)?.animation ?? kAlwaysCompleteAnimation;
+      _routeAnimation!.addStatusListener(_handleAnimationStatusChange);
+    }
+  }
+
+  void _handleAnimationStatusChange(AnimationStatus status) {
+    if (status == AnimationStatus.completed) {
+      if(widget.animation){
+        _animationController?.forward();
+      }
+    }
+  }
+
 
   @override
   Widget build(BuildContext context) {

--- a/lib/linear_percent_indicator.dart
+++ b/lib/linear_percent_indicator.dart
@@ -101,6 +101,9 @@ class LinearPercentIndicator extends StatefulWidget {
   /// Return current percent value if animation is true.
   final Function(double value)? onPercentValue;
 
+  /// set a delay duration in milliseconds to show the progress
+  final int delayDuration;
+
   LinearPercentIndicator({
     Key? key,
     this.fillColor = Colors.transparent,
@@ -132,6 +135,7 @@ class LinearPercentIndicator extends StatefulWidget {
     this.widgetIndicator,
     this.progressBorderColor,
     this.onPercentValue,
+    this.delayDuration = 0,
   }) : super(key: key) {
     if (linearGradient != null && progressColor != null) {
       throw ArgumentError(
@@ -210,7 +214,13 @@ class _LinearPercentIndicatorState extends State<LinearPercentIndicator>
           widget.onAnimationEnd!();
         }
       });
-      _animationController!.forward();
+      if(widget.delayDuration > 0){
+        Future.delayed(Duration(milliseconds: widget.delayDuration), (){
+          _animationController!.forward();
+        });
+      } else {
+        _animationController!.forward();
+      }
     } else {
       _updateProgress();
     }


### PR DESCRIPTION
When switching pages, the animation will start when the UI is loaded. At this time, the animation will jump when it starts. I think we need to provide users with a delayed animation attribute,