### PR TITLE
Add clipRotatedLinearGradient param

### DIFF
--- a/lib/circular_percent_indicator.dart
+++ b/lib/circular_percent_indicator.dart
@@ -107,6 +107,10 @@ class CircularPercentIndicator extends StatefulWidget {
   /// Set to true if you want to rotate linear gradient in accordance to the [startAngle].
   final bool rotateLinearGradient;
 
+  /// Set true if you want to display only part of [linearGradient] based on percent value.
+  /// Works only if [rotateLinearGradient] is true.
+  final bool clipRotatedLinearGradient;
+
   /// Return current percent value if animation is true.
   final Function(double value)? onPercentValue;
 
@@ -140,6 +144,7 @@ class CircularPercentIndicator extends StatefulWidget {
     this.onAnimationEnd,
     this.widgetIndicator,
     this.rotateLinearGradient = false,
+    this.clipRotatedLinearGradient = false,
     this.progressBorderColor,
     this.onPercentValue,
   }) : super(key: key) {
@@ -280,6 +285,7 @@ class _CircularPercentIndicatorState extends State<CircularPercentIndicator>
                 linearGradient: widget.linearGradient,
                 maskFilter: widget.maskFilter,
                 rotateLinearGradient: widget.rotateLinearGradient,
+                clipRotatedLinearGradient: widget.clipRotatedLinearGradient,
               ),
               child: (widget.center != null)
                   ? Center(child: widget.center)
@@ -396,6 +402,7 @@ class _CirclePainter extends CustomPainter {
   final bool reverse;
   final MaskFilter? maskFilter;
   final bool rotateLinearGradient;
+  final bool clipRotatedLinearGradient;
 
   _CirclePainter({
     required this.lineWidth,
@@ -413,6 +420,7 @@ class _CirclePainter extends CustomPainter {
     this.arcType,
     this.maskFilter,
     required this.rotateLinearGradient,
+    required this.clipRotatedLinearGradient,
   }) {
     _paintBackground.color = backgroundColor;
     _paintBackground.style = PaintingStyle.stroke;
@@ -469,7 +477,9 @@ class _CirclePainter extends CustomPainter {
                   radians(-90 - progress + startAngle) - correction)
               : GradientRotation(radians(-90.0 + startAngle) - correction),
           startAngle: radians(0).toDouble(),
-          endAngle: radians(progress).toDouble(),
+          endAngle: clipRotatedLinearGradient
+              ? radians(360).toDouble()
+              : radians(progress).toDouble(),
           tileMode: TileMode.clamp,
           colors: reverse
               ? linearGradient!.colors.reversed.toList()


### PR DESCRIPTION
This PR is related to issue https://github.com/diegoveloper/flutter_percent_indicator/issues/31.

### Problem:
Circular progress indicator's gradient always displays full gradient, even if it is not filled in 100%. It slightly decreases user's experience.

<p>
<img src="https://github.com/user-attachments/assets/e8af8a67-e5e7-414f-8286-99ae77db254e" width=200/>
<img src="https://github.com/user-attachments/assets/11794f70-c5ea-407b-a09f-2e3b0acd6997" width=200/>
</p>

### Proposed solution:
Inspired by `LinearPercentIndicator`'s `clipLinearGradient` parameter, I have added `clipRotatedLinearGradient` parameter to `CircularPercentIndicator` widget. Behaviour is similar as in Linear one - gradient gets built fully, but is displayed partially.

<p>
<img src="https://github.com/user-attachments/assets/3cb513cc-250f-497a-8e0f-30516f2606be"/>
<img src="https://github.com/user-attachments/assets/9855e9ea-0f30-434d-9c2c-784bb8fe70b7"/>
</p>
