### PR TITLE
Add `countdown` param to `LinearPercentIndicator`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,7 +45,7 @@
 
 - `linearGradientBackgroundColor` was added for `LinearPercentIndicator`. Thanks Jeremiah Parrack.
 
-# [3.3.0-nullsafety.1 - 3.0.0]
+# [3.0.0]
 
 - Null safety migration.
 
@@ -134,11 +134,11 @@
 
 - padding property was added for LinearPercentIndicator
 
-# 1.0.7, 1.0.8
+# 1.0.7 - 1.0.8
 
 - alignment property was added for LinearPercentIndicator
 
-# 1.0.5, 1.0.6
+# 1.0.5 - 1.0.6
 
 - fillColor property was added to LinearPercentIndicator
 
@@ -148,20 +148,4 @@
 
 # 1.0.0
 
-Initial release of the multi_segment_linear_indicator package.
-
-### Features
-
-- Three independently animated segments
-- Customizable colors for each segment
-- Optional striped pattern for the middle segment
-- Smooth animations with customizable duration and curve
-- Configurable border radius
-- RTL support
-- Flexible sizing and padding options
-
-### Documentation
-
-- Added comprehensive README with usage examples
-- Added API documentation
-- Added example application
+- Initial release

--- a/README.md
+++ b/README.md
@@ -299,6 +299,10 @@ Complete example
   }
 ```
 
+<p align="center">
+  <img src="https://media.giphy.com/media/88j2PmdEqCrLq2pZxO/giphy.gif">
+</p>
+
 **Multi-segment linear indicator**
 
 Basic Widget

--- a/example/lib/sample_circular_page.dart
+++ b/example/lib/sample_circular_page.dart
@@ -58,6 +58,7 @@ class _SampleCircularPageState extends State<SampleCircularPage> {
               ),
               arcBackgroundColor: Colors.grey,
             ),
+            const SizedBox(height: 20),
             CircularPercentIndicator(
               radius: 60.0,
               animation: true,
@@ -99,6 +100,7 @@ class _SampleCircularPageState extends State<SampleCircularPage> {
               ),
               arcBackgroundColor: Colors.grey,
             ),
+            const SizedBox(height: 20),
             CircularPercentIndicator(
               radius: 60.0,
               lineWidth: 13.0,
@@ -121,6 +123,7 @@ class _SampleCircularPageState extends State<SampleCircularPage> {
                 child: Icon(Icons.airplanemode_active, size: 30),
               ),
             ),
+            const SizedBox(height: 20),
             CircularPercentIndicator(
               radius: 50.0,
               lineWidth: 10.0,
@@ -135,6 +138,7 @@ class _SampleCircularPageState extends State<SampleCircularPage> {
                 colors: [Colors.orange, Colors.yellow],
               ),
             ),
+            const SizedBox(height: 20),
             CircularPercentIndicator(
               radius: 50.0,
               lineWidth: 10.0,
@@ -149,6 +153,7 @@ class _SampleCircularPageState extends State<SampleCircularPage> {
               backgroundColor: Colors.grey,
               progressColor: Colors.blue,
             ),
+            const SizedBox(height: 20),
             Row(mainAxisAlignment: MainAxisAlignment.spaceEvenly, children: [
               CircularPercentIndicator(
                 radius: 50.0,
@@ -184,6 +189,7 @@ class _SampleCircularPageState extends State<SampleCircularPage> {
                 progressColor: Colors.red,
               ),
             ]),
+            const SizedBox(height: 20),
             CircularPercentIndicator(
               radius: 50.0,
               animation: true,
@@ -200,6 +206,7 @@ class _SampleCircularPageState extends State<SampleCircularPage> {
               backgroundColor: Colors.grey,
               progressColor: Colors.red,
             ),
+            const SizedBox(height: 20),
             CircularPercentIndicator(
               radius: 60.0,
               lineWidth: 13.0,
@@ -218,18 +225,17 @@ class _SampleCircularPageState extends State<SampleCircularPage> {
               circularStrokeCap: CircularStrokeCap.round,
               progressColor: Colors.purple,
             ),
-            Padding(
-              padding: EdgeInsets.all(15.0),
-              child: CircularPercentIndicator(
-                radius: 30.0,
-                lineWidth: 5.0,
-                percent: 1.0,
-                center: Text("100%"),
-                progressColor: Colors.green,
-              ),
+            const SizedBox(height: 20),
+            CircularPercentIndicator(
+              radius: 30.0,
+              lineWidth: 5.0,
+              percent: 1.0,
+              center: Text("100%"),
+              progressColor: Colors.green,
             ),
+            const SizedBox(height: 20),
             Container(
-              padding: EdgeInsets.all(15.0),
+              padding: EdgeInsets.symmetric(horizontal: 15.0),
               child: SingleChildScrollView(
                 scrollDirection: Axis.horizontal,
                 child: Row(
@@ -305,6 +311,7 @@ class _SampleCircularPageState extends State<SampleCircularPage> {
                 ),
               ),
             ),
+            const SizedBox(height: 20),
             CircularPercentIndicator(
               radius: 40.0,
               lineWidth: 5.0,
@@ -403,6 +410,76 @@ class _SampleCircularPageState extends State<SampleCircularPage> {
                 ),
               ],
             ),
+            const SizedBox(height: 20),
+            Padding(
+              padding: const EdgeInsets.only(bottom: 18.0),
+              child: Center(
+                child: Text(
+                  "Circular with (rotated) gradient",
+                  style: TextStyle(fontWeight: FontWeight.bold, fontSize: 17.0),
+                ),
+              ),
+            ),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+              children: [
+                CircularPercentIndicator(
+                  radius: 40.0,
+                  percent: 0.6,
+                  lineWidth: 10,
+                  backgroundWidth: 10,
+                  backgroundColor: Colors.grey,
+                  animation: true,
+                  animationDuration: 2000,
+                  center: Text("60.0%"),
+                  linearGradient: const LinearGradient(
+                    colors: <Color>[
+                      Colors.red,
+                      Colors.yellow,
+                      Colors.green,
+                    ],
+                  ),
+                ),
+                CircularPercentIndicator(
+                  radius: 40.0,
+                  percent: 0.6,
+                  lineWidth: 10,
+                  backgroundWidth: 10,
+                  backgroundColor: Colors.grey,
+                  animation: true,
+                  animationDuration: 2000,
+                  center: Text("60.0%"),
+                  linearGradient: const LinearGradient(
+                    colors: <Color>[
+                      Colors.red,
+                      Colors.yellow,
+                      Colors.green,
+                    ],
+                  ),
+                  rotateLinearGradient: true,
+                ),
+                CircularPercentIndicator(
+                  radius: 40.0,
+                  percent: 0.6,
+                  lineWidth: 10,
+                  backgroundWidth: 10,
+                  backgroundColor: Colors.grey,
+                  animation: true,
+                  animationDuration: 2000,
+                  center: Text("60.0%"),
+                  linearGradient: const LinearGradient(
+                    colors: <Color>[
+                      Colors.red,
+                      Colors.yellow,
+                      Colors.green,
+                    ],
+                  ),
+                  rotateLinearGradient: true,
+                  clipRotatedLinearGradient: true,
+                ),
+              ],
+            ),
+            const SizedBox(height: 20),
           ],
         ),
       ),

--- a/example/lib/sample_linear_page.dart
+++ b/example/lib/sample_linear_page.dart
@@ -315,7 +315,7 @@ class _SampleLinearPageState extends State<SampleLinearPage> {
                       animation: true,
                       animationDuration: 2000,
                       isRTL: true,
-                      reverse: true,
+                      countdown: true,
                     ),
                   ],
                 ),

--- a/example/lib/sample_linear_page.dart
+++ b/example/lib/sample_linear_page.dart
@@ -27,6 +27,7 @@ class _SampleLinearPageState extends State<SampleLinearPage> {
       ),
       body: Center(
         child: SingleChildScrollView(
+          padding: EdgeInsets.symmetric(vertical: 15.0),
           child: Column(
             mainAxisAlignment: MainAxisAlignment.center,
             children: <Widget>[
@@ -289,6 +290,37 @@ class _SampleLinearPageState extends State<SampleLinearPage> {
                 ),
               ),
               Text('Custom Border Color'),
+              Container(
+                color: Colors.white,
+                margin: EdgeInsets.all(15),
+                width: 150,
+                child: Stack(
+                  children: [
+                    Row(
+                      mainAxisAlignment: MainAxisAlignment.spaceAround,
+                      children: List.generate(
+                        5,
+                        (_) => Icon(
+                          Icons.star,
+                          size: 20,
+                        ),
+                      ),
+                    ),
+                    LinearPercentIndicator(
+                      lineHeight: 20,
+                      progressColor: Colors.white.withOpacity(0.75),
+                      backgroundColor: Colors.transparent,
+                      padding: EdgeInsets.zero,
+                      percent: 0.5,
+                      animation: true,
+                      animationDuration: 2000,
+                      isRTL: true,
+                      reverse: true,
+                    ),
+                  ],
+                ),
+              ),
+              Text('Reversed RTL Animation'),
             ],
           ),
         ),

--- a/lib/linear_percent_indicator.dart
+++ b/lib/linear_percent_indicator.dart
@@ -80,6 +80,9 @@ class LinearPercentIndicator extends StatefulWidget {
   /// set true if you want to animate the linear from the right to left (RTL)
   final bool isRTL;
 
+  /// set true when you want to display the progress in reverse mode
+  final bool reverse;
+
   /// Creates a mask filter that takes the progress shape being drawn and blurs it.
   final MaskFilter? maskFilter;
 
@@ -118,6 +121,7 @@ class LinearPercentIndicator extends StatefulWidget {
     this.animateFromLastPercent = false,
     this.animateToInitialPercent = true,
     this.isRTL = false,
+    this.reverse = false,
     this.leading,
     this.trailing,
     this.center,
@@ -279,6 +283,7 @@ class _LinearPercentIndicatorState extends State<LinearPercentIndicator>
               key: _containerKey,
               painter: _LinearPainter(
                 isRTL: widget.isRTL,
+                reverse: widget.reverse,
                 progress: _percent,
                 progressColor: widget.progressColor,
                 linearGradient: widget.linearGradient,
@@ -348,6 +353,7 @@ class _LinearPainter extends CustomPainter {
   final Paint _paintLineBorder = new Paint();
   final double progress;
   final bool isRTL;
+  final bool reverse;
   final Color progressColor;
   final Color? progressBorderColor;
   final Color backgroundColor;
@@ -360,6 +366,7 @@ class _LinearPainter extends CustomPainter {
   _LinearPainter({
     required this.progress,
     required this.isRTL,
+    required this.reverse,
     required this.progressColor,
     required this.backgroundColor,
     required this.barRadius,
@@ -371,11 +378,12 @@ class _LinearPainter extends CustomPainter {
   }) {
     _paintBackground.color = backgroundColor;
 
-    _paintLine.color =
-        progress == 0 ? progressColor.withOpacity(0.0) : progressColor;
+    _paintLine.color = progress == 0 && !reverse
+        ? progressColor.withOpacity(0.0)
+        : progressColor;
 
     if (progressBorderColor != null) {
-      _paintLineBorder.color = progress == 0
+      _paintLineBorder.color = progress == 0 && !reverse
           ? progressBorderColor!.withOpacity(0.0)
           : progressBorderColor!;
     }
@@ -403,7 +411,7 @@ class _LinearPainter extends CustomPainter {
     }
 
     // Then draw progress line
-    final xProgress = size.width * progress;
+    final xProgress = size.width * (reverse ? 1 - progress : progress);
     Path linePath = Path();
     Path linePathBorder = Path();
     double factor = progressBorderColor != null ? 2 : 0;
@@ -415,8 +423,7 @@ class _LinearPainter extends CustomPainter {
         _paintLine.shader = _createGradientShaderRightToLeft(size, xProgress);
       }
       linePath.addRRect(RRect.fromRectAndRadius(
-          Rect.fromLTWH(
-              size.width - size.width * progress, 0, xProgress, size.height),
+          Rect.fromLTWH(size.width - xProgress, 0, xProgress, size.height),
           barRadius));
     } else {
       if (linearGradient != null) {

--- a/lib/linear_percent_indicator.dart
+++ b/lib/linear_percent_indicator.dart
@@ -80,8 +80,8 @@ class LinearPercentIndicator extends StatefulWidget {
   /// set true if you want to animate the linear from the right to left (RTL)
   final bool isRTL;
 
-  /// set true when you want to display the progress in reverse mode
-  final bool reverse;
+  /// set to true when you want to proceed from 1.0 to 0.0 instead of 0.0 to 1.0
+  final bool countdown;
 
   /// Creates a mask filter that takes the progress shape being drawn and blurs it.
   final MaskFilter? maskFilter;
@@ -121,7 +121,7 @@ class LinearPercentIndicator extends StatefulWidget {
     this.animateFromLastPercent = false,
     this.animateToInitialPercent = true,
     this.isRTL = false,
-    this.reverse = false,
+    this.countdown = false,
     this.leading,
     this.trailing,
     this.center,
@@ -283,7 +283,7 @@ class _LinearPercentIndicatorState extends State<LinearPercentIndicator>
               key: _containerKey,
               painter: _LinearPainter(
                 isRTL: widget.isRTL,
-                reverse: widget.reverse,
+                countdown: widget.countdown,
                 progress: _percent,
                 progressColor: widget.progressColor,
                 linearGradient: widget.linearGradient,
@@ -353,7 +353,7 @@ class _LinearPainter extends CustomPainter {
   final Paint _paintLineBorder = new Paint();
   final double progress;
   final bool isRTL;
-  final bool reverse;
+  final bool countdown;
   final Color progressColor;
   final Color? progressBorderColor;
   final Color backgroundColor;
@@ -366,7 +366,7 @@ class _LinearPainter extends CustomPainter {
   _LinearPainter({
     required this.progress,
     required this.isRTL,
-    required this.reverse,
+    required this.countdown,
     required this.progressColor,
     required this.backgroundColor,
     required this.barRadius,
@@ -378,12 +378,12 @@ class _LinearPainter extends CustomPainter {
   }) {
     _paintBackground.color = backgroundColor;
 
-    _paintLine.color = progress == 0 && !reverse
+    _paintLine.color = progress == 0 && !countdown
         ? progressColor.withOpacity(0.0)
         : progressColor;
 
     if (progressBorderColor != null) {
-      _paintLineBorder.color = progress == 0 && !reverse
+      _paintLineBorder.color = progress == 0 && !countdown
           ? progressBorderColor!.withOpacity(0.0)
           : progressBorderColor!;
     }
@@ -411,7 +411,7 @@ class _LinearPainter extends CustomPainter {
     }
 
     // Then draw progress line
-    final xProgress = size.width * (reverse ? 1 - progress : progress);
+    final xProgress = size.width * (countdown ? 1 - progress : progress);
     Path linePath = Path();
     Path linePathBorder = Path();
     double factor = progressBorderColor != null ? 2 : 0;


### PR DESCRIPTION
In the project I am working on I needed to add an animation of few icons that are filling up. Current version of `flutter_percent_indicator` does not provide such functionality, but I have realised that semi-transparent progress bar can be above a Row with icons and, by shrinking from left to right, it will give expected illusion. As a result, I have added a `countdown` param to LinearPercentIndicator, which, combined with `isRTL`, gives this:

![reverseRTL](https://github.com/user-attachments/assets/83818023-3738-4a5b-9394-c540fe7791b0)

Example from the gif was added to library's example directory. I suppose there can be more usages of this param, so I decided to share it with you.

PS. I have also fixed the changelog (something was added there accidentally before last release), brought back missing image to readme (again, probably removed accidentally) and added example of using clipRotatedLinearGradient param 💪 